### PR TITLE
248312:  Addition of new network policy to fix Calico API server intermittent error

### DIFF
--- a/adp-calico-helm-chart/Chart.yaml
+++ b/adp-calico-helm-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: adp-calico-helm-chart
 description: ADP Calico Helm Chart
-version: 0.1.0
+version: 0.1.1

--- a/adp-calico-helm-chart/templates/global-network-policy.yaml
+++ b/adp-calico-helm-chart/templates/global-network-policy.yaml
@@ -2,6 +2,22 @@
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
 metadata:
+  name: allow-ingress-gatekeeper-system
+spec:
+  order: 940
+  types:
+  - Ingress
+  ingress:
+  - action: Allow
+    destination:
+      namespaceSelector: kubernetes.io/metadata.name == 'gatekeeper-system'
+    source: {}
+    protocol: TCP
+---
+
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
   name: allow-nginx-ingress-team-namespaces
 spec:
   order: 950


### PR DESCRIPTION
We have noticed the following error in the logs and the Calico-ApiServer pods intermittently going into a crash loop backoff.  

```
W0226 10:26:01.961415       1 dispatcher.go:176] Failed calling webhook, failing open validation.gatekeeper.sh: failed calling webhook "validation.gatekeeper.sh": failed to call webhook: Post "https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admit?timeout=3s": context deadline exceeded
E0226 10:26:01.961454       1 dispatcher.go:183] failed calling webhook "validation.gatekeeper.sh": failed to call webhook: Post "https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admit?timeout=3s": context deadline exceeded
```

This policy will fix the issue.

[AB#248312](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/248312)

# Testing
Tested in DEV environment successfully

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)